### PR TITLE
Feature/121 Status syllable display V2

### DIFF
--- a/src/functions/syllabus/syllabus.controller.ts
+++ b/src/functions/syllabus/syllabus.controller.ts
@@ -8,7 +8,10 @@ import { SyllabusService } from "../../service/syllabus.service";
 import { route, controller } from "../../lib/decorators";
 import { STATUS_CODES } from "../../status-codes";
 import { SilaboRepository } from "../../repositories/silabo.repository";
+import { SyllabusStateService } from "../../service/syllabusState.service";
+
 import { SilaboFuenteRepository } from "../../repositories/silaboFuente.repository";
+import { log } from "console";
 
 interface UpdateRecursosDidacticosDto {
   recursosDidacticos: string;
@@ -19,6 +22,7 @@ export class SyllabusController implements BaseController {
   private repo = new SilaboRepository();
   private repoFuente = new SilaboFuenteRepository();
   private syllabusService = new SyllabusService();
+  private syllabusStateService = new SyllabusStateService();
 
   @route("/")
   async list(
@@ -38,24 +42,42 @@ export class SyllabusController implements BaseController {
     req: HttpRequest,
     context: InvocationContext,
   ): Promise<HttpResponseInit> {
-    // try {
     const id = req.params.id;
     const response = await this.syllabusService.getOne(id);
+
+    if (!response) {
+      return {
+        status: STATUS_CODES.NOT_FOUND,
+        jsonBody: { message: "Silabo no encontrado" },
+      };
+    }
     return {
       status: STATUS_CODES.OK,
       jsonBody: {
         response,
       },
     };
-    // } catch (e) {
-    //   return {
-    //     status: STATUS_CODES.INTERNAL_SERVER_ERROR,
-    //     jsonBody: {
-    //       code: "INTERAL_SERVER_ERROR",
-    //       message: "Un error desconocido ha ocurrido",
-    //     },
-    //   };
-    // }
+  }
+
+  @route("/{id}/estado")
+  async getState(
+    req: HttpRequest,
+    context: InvocationContext,
+  ): Promise<HttpResponseInit> {
+    const id = req.params.id;
+    const response = await this.syllabusStateService.getState(id);
+
+    if (!response) {
+      return {
+        status: STATUS_CODES.NOT_FOUND,
+        jsonBody: { message: "Estado del Silabo " + id + " no encontrado" },
+      };
+    }
+
+    return {
+      status: STATUS_CODES.OK,
+      jsonBody: { message: "Estado del silabo " + id, state: response },
+    };
   }
 
   @route("/", "POST")

--- a/src/repositories/syllabusState.repository.ts
+++ b/src/repositories/syllabusState.repository.ts
@@ -1,0 +1,24 @@
+import { eq } from "drizzle-orm";
+import { getDb } from "../db/index";
+import { silabo } from "../../drizzle/schema";
+import { log } from "console";
+
+export class SyllabusStateRepository {
+  private db = getDb();
+
+  async findById(id: string) {
+    if (!this.db) {
+      throw new Error("Database connection is not initialized.");
+    }
+
+    const numericIdSilabo = Number(id);
+
+    log("ESTE ES EL ID" + numericIdSilabo);
+    const stateSyllable = await this.db
+      .select(/*estado*/) // <- aqui corresponde el campo estado de la tabla
+      .from(silabo)
+      .where(eq(silabo.id, numericIdSilabo));
+
+    return stateSyllable ? stateSyllable : null;
+  }
+}

--- a/src/service/syllabusState.service.ts
+++ b/src/service/syllabusState.service.ts
@@ -1,0 +1,15 @@
+import { SyllabusStateRepository } from "../repositories/syllabusState.repository";
+
+export class SyllabusStateService {
+  private syllabusRepo = new SyllabusStateRepository();
+
+  async getState(id: string) {
+    const syllableState = await this.syllabusRepo.findById(id);
+
+    if (!syllableState) {
+      throw new Error("State for syllable not found");
+    }
+
+    return syllableState;
+  }
+}


### PR DESCRIPTION
## 📝 Descripción

_Describe brevemente qué funcionalidad o cambio incluye este PR_

Se desarrolló un endpoint que permite obtener únicamente el estado de un sílabo mediante su ID.
La ruta recibe el parámetro id, consulta el servicio correspondiente y devuelve un JSON con el campo estado.
Dicho endpoint se encuentra en syllabus.controller.ts, se creo un archivo syllabusState.repository.ts para realizar la consulta a la BD y syllabusState.service.ts, para obedecer la arquitectura de capas.
---

## ✅ ¿Qué se incluye en este PR?

- [ ] Nueva funcionalidad Frontend
- [X] Nueva funcionalidad Backend
- [ ] Caso de prueba
- [ ] Refactor / Ajuste
- [ ] Otro (especificar):

---

## 🧪 Cómo probarlo

_Pasos o comandos para validar este cambio localmente_

npm install para instalar las dependencias necesarias
npm run format:write para formatear archivos del proyecto
npm run start para correr el proyecto
Usando un agente externo ingresar a la siguiente dirección:  http://localhost:7071/api/syllabus/{id}/estado

```bash
# ejemplo
npm install
npm run dev
```
