### PR TITLE
feat: recibir e importar silabo con firma HU 3.0-3.1

### DIFF
--- a/drizzle/0001_short_risque.sql
+++ b/drizzle/0001_short_risque.sql
@@ -1,0 +1,399 @@
+CREATE TABLE "audit_event" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"tabla" varchar NOT NULL,
+	"registro_pk" varchar NOT NULL,
+	"accion" varchar NOT NULL,
+	"descripcion" text,
+	"docente_id" integer,
+	"ip_origen" varchar,
+	"user_agent" varchar,
+	"old_values" json,
+	"new_values" json,
+	"silabo_id" integer,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "categoria_funcion" (
+	"categoria_usuario_id" integer NOT NULL,
+	"funcion_aplicacion_id" integer NOT NULL,
+	CONSTRAINT "categoria_funcion_acceso_pk" PRIMARY KEY("categoria_usuario_id","funcion_aplicacion_id")
+);
+--> statement-breakpoint
+CREATE TABLE "docente" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"correo" varchar NOT NULL,
+	"categoria_usuario_id" integer NOT NULL,
+	"activo" boolean DEFAULT true,
+	"azure_ad_object_id" varchar,
+	"tenant_id" varchar,
+	"ultimo_acceso_en" timestamp,
+	"grado_academico" varchar,
+	"creado_en" timestamp DEFAULT now(),
+	"actualizado_en" timestamp DEFAULT now(),
+	"nombre_docente" varchar(100),
+	"grado_academico_id" integer,
+	"numero_celular" varchar(9) DEFAULT '999999999' NOT NULL,
+	CONSTRAINT "docente_correo_key" UNIQUE("correo"),
+	CONSTRAINT "uq_docente_numero_celular" UNIQUE("numero_celular"),
+	CONSTRAINT "ck_docente_numero_celular_9dig" CHECK ((numero_celular)::text ~ '^[9][0-9]{8}$'::text)
+);
+--> statement-breakpoint
+CREATE TABLE "evaluacion_aprendizaje" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"fecha_creacion" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	"formula_regla_id" integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "formula_evaluacion_regla" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"nombre_regla" varchar NOT NULL,
+	"variable_final_codigo" varchar NOT NULL,
+	"expresion_final" text NOT NULL,
+	"descripcion" text,
+	"version" integer DEFAULT 1,
+	"activo" boolean DEFAULT true,
+	"lenguaje" varchar DEFAULT 'INFIX',
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "formula_evaluacion_regla_unq" UNIQUE("silabo_id","nombre_regla","version"),
+	CONSTRAINT "uq_regla_silabo_nombre_version" UNIQUE("silabo_id","nombre_regla","version")
+);
+--> statement-breakpoint
+CREATE TABLE "formula_evaluacion_subformula" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"formula_evaluacion_regla_id" integer NOT NULL,
+	"variable_codigo" varchar NOT NULL,
+	"expresion" text NOT NULL,
+	CONSTRAINT "formula_evaluacion_subformula_unq" UNIQUE("formula_evaluacion_regla_id","variable_codigo"),
+	CONSTRAINT "uq_subformula_regla_var" UNIQUE("formula_evaluacion_regla_id","variable_codigo"),
+	CONSTRAINT "formula_subf_uk" UNIQUE("formula_evaluacion_regla_id","variable_codigo")
+);
+--> statement-breakpoint
+CREATE TABLE "formula_evaluacion_variable" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"formula_evaluacion_regla_id" integer NOT NULL,
+	"codigo" varchar NOT NULL,
+	"nombre" varchar NOT NULL,
+	"tipo" varchar NOT NULL,
+	"descripcion" text,
+	"orden" integer,
+	CONSTRAINT "formula_evaluacion_variable_unq" UNIQUE("formula_evaluacion_regla_id","codigo"),
+	CONSTRAINT "uq_variable_regla_codigo" UNIQUE("formula_evaluacion_regla_id","codigo")
+);
+--> statement-breakpoint
+CREATE TABLE "formula_evaluacion_variable_plan" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"formula_evaluacion_regla_id" integer NOT NULL,
+	"variable_codigo" varchar NOT NULL,
+	"plan_evaluacion_oferta_id" integer NOT NULL,
+	CONSTRAINT "formula_evaluacion_variable_plan_unq" UNIQUE("formula_evaluacion_regla_id","variable_codigo","plan_evaluacion_oferta_id"),
+	CONSTRAINT "uq_var_plan_regla_var_plan" UNIQUE("formula_evaluacion_regla_id","variable_codigo","plan_evaluacion_oferta_id")
+);
+--> statement-breakpoint
+CREATE TABLE "grado_academico_catalogo" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"codigo" varchar NOT NULL,
+	"nombre" varchar NOT NULL,
+	"abreviatura" varchar,
+	"activo" boolean DEFAULT true,
+	"creado_en" timestamp DEFAULT now(),
+	"actualizado_en" timestamp DEFAULT now(),
+	CONSTRAINT "grado_academico_catalogo_codigo_key" UNIQUE("codigo")
+);
+--> statement-breakpoint
+CREATE TABLE "plan_evaluacion_oferta" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"componente_nombre" varchar NOT NULL,
+	"instrumento_nombre" varchar,
+	"semana" integer,
+	"fecha" date,
+	"instrucciones" text,
+	"rubrica_url" varchar,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "plan_evaluacion_oferta_unq" UNIQUE("silabo_id","componente_nombre","semana"),
+	CONSTRAINT "uq_plan_eval_silabo_comp_semana" UNIQUE("silabo_id","componente_nombre","semana")
+);
+--> statement-breakpoint
+CREATE TABLE "recurso_didactico_catalogo" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"codigo" varchar NOT NULL,
+	"nombre" varchar NOT NULL,
+	"descripcion" text,
+	"activo" boolean DEFAULT true,
+	"creado_en" timestamp DEFAULT now(),
+	"actualizado_en" timestamp DEFAULT now(),
+	CONSTRAINT "recurso_didactico_catalogo_codigo_key" UNIQUE("codigo")
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_competencia_componente" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"grupo" varchar NOT NULL,
+	"codigo" varchar,
+	"descripcion" text NOT NULL,
+	"competencia_codigo_relacionada" varchar,
+	"orden" integer,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_competencia_curso" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"codigo" varchar,
+	"descripcion" text NOT NULL,
+	"referencia_programa_codigo" varchar,
+	"orden" integer,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_docente" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"docente_id" integer NOT NULL,
+	"observaciones" text,
+	"creado_en" timestamp DEFAULT now(),
+	"actualizado_en" timestamp DEFAULT now(),
+	"rol" varchar NOT NULL,
+	CONSTRAINT "silabo_docente_unq" UNIQUE("silabo_id","docente_id"),
+	CONSTRAINT "uq_silabo_docente_silabo_docente" UNIQUE("silabo_id","docente_id"),
+	CONSTRAINT "uq_silabo_docente" UNIQUE("silabo_id","docente_id","rol")
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_recurso_didactico" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"recurso_id" integer NOT NULL,
+	"silabo_unidad_id" integer,
+	"destino" varchar,
+	"url_referencia" varchar,
+	"observaciones" text,
+	"creado_en" timestamp DEFAULT now(),
+	"actualizado_en" timestamp DEFAULT now(),
+	"clave_unica" text GENERATED ALWAYS AS ((((((((silabo_id)::text || '-'::text) || (recurso_id)::text) || '-'::text) || COALESCE((silabo_unidad_id)::text, '0'::text)) || '-'::text) || (COALESCE(destino, ''::character varying))::text)) STORED,
+	CONSTRAINT "uq_recurso_por_silabo" UNIQUE("silabo_id","recurso_id"),
+	CONSTRAINT "uq_silabo_recurso" UNIQUE("clave_unica")
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_resultado_aprendizaje" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"descripcion" text NOT NULL,
+	"orden" integer,
+	CONSTRAINT "silabo_ra_uk" UNIQUE("silabo_id","orden")
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_revision_comentario" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_revision_seccion_id" integer NOT NULL,
+	"autor_id" integer,
+	"mensaje" text NOT NULL,
+	"creado_en" timestamp DEFAULT now(),
+	"leido" boolean DEFAULT false
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_revision_historial" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"revisor_id" integer NOT NULL,
+	"accion" varchar NOT NULL,
+	"descripcion" text,
+	"creado_en" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_revision_seccion" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"numero_seccion" integer NOT NULL,
+	"nombre_seccion" varchar NOT NULL,
+	"estado" varchar DEFAULT 'PENDIENTE' NOT NULL,
+	"revisado_por" integer,
+	"revisado_en" timestamp DEFAULT now(),
+	"comentarios_count" integer DEFAULT 0,
+	CONSTRAINT "uq_rev_seccion_silabo_num" UNIQUE("silabo_id","numero_seccion")
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_seccion_permiso" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"docente_id" integer NOT NULL,
+	"numero_seccion" integer NOT NULL,
+	"puede_editar" boolean DEFAULT false NOT NULL,
+	"puede_comentar" boolean DEFAULT true NOT NULL,
+	"fecha_limite" timestamp,
+	"bloqueado_por_estado" boolean DEFAULT false NOT NULL,
+	"creado_en" timestamp DEFAULT now() NOT NULL,
+	"actualizado_en" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_permiso_silabo_docente_seccion" UNIQUE("silabo_id","docente_id","numero_seccion")
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_sumilla" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"silabo_id" integer NOT NULL,
+	"contenido" text NOT NULL,
+	"palabras_clave" text,
+	"version" integer DEFAULT 1,
+	"es_actual" boolean DEFAULT true,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "silabo_sumilla_unq" UNIQUE("silabo_id","version"),
+	CONSTRAINT "uq_silabo_sumilla_silabo_version" UNIQUE("silabo_id","version")
+);
+--> statement-breakpoint
+CREATE TABLE "silabo_unidad_backup" (
+	"id" integer,
+	"silabo_id" integer,
+	"numero" integer,
+	"titulo" varchar,
+	"capacidades_text" text,
+	"contenidos_conceptuales" text,
+	"contenidos_procedimentales" text,
+	"actividades_aprendizaje" text,
+	"horas_lectivas_teoria" integer,
+	"horas_lectivas_practica" integer,
+	"horas_no_lectivas_teoria" integer,
+	"horas_no_lectivas_practica" integer,
+	"contenidos_conceptuales_semana" text,
+	"contenidos_procedimentales_semana" text,
+	"actividades_aprendizaje_semana" text,
+	"horas_lectivas_teoria_semana_arr" smallint,
+	"horas_lectivas_practica_semana_arr" smallint,
+	"horas_no_lectivas_teoria_semana_arr" smallint,
+	"horas_no_lectivas_practica_semana_arr" smallint
+);
+--> statement-breakpoint
+ALTER TABLE "silabo_unidad_contenido" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "silabo_evaluacion" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "silabo_resultado_aprendizaje_curso" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "usuario_autorizado" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "categoria_funcion_acceso" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "silabo_unidad_contenido" CASCADE;--> statement-breakpoint
+DROP TABLE "silabo_evaluacion" CASCADE;--> statement-breakpoint
+DROP TABLE "silabo_resultado_aprendizaje_curso" CASCADE;--> statement-breakpoint
+DROP TABLE "usuario_autorizado" CASCADE;--> statement-breakpoint
+DROP TABLE "categoria_funcion_acceso" CASCADE;--> statement-breakpoint
+ALTER TABLE "funcion_aplicacion" DROP CONSTRAINT "funcion_aplicacion_nombre_funcion_key";--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" DROP CONSTRAINT "silabo_unidad_semana_silabo_unidad_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "silabo" DROP CONSTRAINT "silabo_actualizado_por_usuario_autorizado_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "silabo" DROP CONSTRAINT "silabo_asignado_a_usuario_autorizado_id_fkey";
+--> statement-breakpoint
+ALTER TABLE "silabo" DROP CONSTRAINT "silabo_creado_por_usuario_autorizado_id_fkey";
+--> statement-breakpoint
+DROP INDEX "idx_semana_unidad";--> statement-breakpoint
+DROP INDEX "idx_fuente_silabo";--> statement-breakpoint
+DROP INDEX "idx_silabo_actualizado";--> statement-breakpoint
+DROP INDEX "idx_silabo_asignado";--> statement-breakpoint
+DROP INDEX "idx_silabo_creado_por";--> statement-breakpoint
+DROP INDEX "idx_unidad_silabo";--> statement-breakpoint
+ALTER TABLE "silabo_aporte_resultado_programa" DROP CONSTRAINT "silabo_aporte_resultado_programa_pkey";--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ALTER COLUMN "semana" SET DATA TYPE smallint;--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ALTER COLUMN "horas_lectivas_teoria" SET DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ALTER COLUMN "horas_lectivas_practica" SET DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ALTER COLUMN "horas_no_lectivas_teoria" SET DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ALTER COLUMN "horas_no_lectivas_practica" SET DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "silabo_aporte_resultado_programa" ALTER COLUMN "aporte_valor" SET DATA TYPE varchar;--> statement-breakpoint
+ALTER TABLE "silabo_aporte_resultado_programa" ADD CONSTRAINT "silabo_aporte_resultado_programa_pk" PRIMARY KEY("silabo_id","resultado_programa_codigo");--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ADD COLUMN "creado_en" timestamp DEFAULT now();--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ADD COLUMN "actualizado_en" timestamp DEFAULT now();--> statement-breakpoint
+ALTER TABLE "funcion_aplicacion" ADD COLUMN "codigo" varchar NOT NULL;--> statement-breakpoint
+ALTER TABLE "funcion_aplicacion" ADD COLUMN "nombre_publico" varchar;--> statement-breakpoint
+ALTER TABLE "silabo" ADD COLUMN "recursos_didacticos_notas" text;--> statement-breakpoint
+ALTER TABLE "silabo" ADD COLUMN "estado_revision" varchar DEFAULT 'ASIGNADO' NOT NULL;--> statement-breakpoint
+ALTER TABLE "silabo" ADD COLUMN "asignado_a_docente_id" integer;--> statement-breakpoint
+ALTER TABLE "silabo" ADD COLUMN "creado_por_docente_id" integer;--> statement-breakpoint
+ALTER TABLE "silabo" ADD COLUMN "actualizado_por_docente_id" integer;--> statement-breakpoint
+ALTER TABLE "silabo" ADD COLUMN "horasTotales" integer;--> statement-breakpoint
+ALTER TABLE "silabo" ADD COLUMN "creditosTotales" integer;--> statement-breakpoint
+ALTER TABLE "silabo_unidad" ADD COLUMN "contenidos_conceptuales" text;--> statement-breakpoint
+ALTER TABLE "silabo_unidad" ADD COLUMN "contenidos_procedimentales" text;--> statement-breakpoint
+ALTER TABLE "silabo_unidad" ADD COLUMN "actividades_aprendizaje" text;--> statement-breakpoint
+ALTER TABLE "silabo_unidad" ADD COLUMN "horas_lectivas_teoria" integer;--> statement-breakpoint
+ALTER TABLE "silabo_unidad" ADD COLUMN "horas_lectivas_practica" integer;--> statement-breakpoint
+ALTER TABLE "silabo_unidad" ADD COLUMN "horas_no_lectivas_teoria" integer;--> statement-breakpoint
+ALTER TABLE "silabo_unidad" ADD COLUMN "horas_no_lectivas_practica" integer;--> statement-breakpoint
+ALTER TABLE "audit_event" ADD CONSTRAINT "audit_event_docente_id_fkey" FOREIGN KEY ("docente_id") REFERENCES "public"."docente"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "audit_event" ADD CONSTRAINT "audit_event_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "categoria_funcion" ADD CONSTRAINT "categoria_funcion_acceso_categoria_usuario_id_fkey" FOREIGN KEY ("categoria_usuario_id") REFERENCES "public"."categoria_usuario"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "categoria_funcion" ADD CONSTRAINT "categoria_funcion_acceso_funcion_aplicacion_id_fkey" FOREIGN KEY ("funcion_aplicacion_id") REFERENCES "public"."funcion_aplicacion"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "docente" ADD CONSTRAINT "docente_categoria_usuario_id_fkey" FOREIGN KEY ("categoria_usuario_id") REFERENCES "public"."categoria_usuario"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "docente" ADD CONSTRAINT "docente_grado_academico_id_fkey" FOREIGN KEY ("grado_academico_id") REFERENCES "public"."grado_academico_catalogo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluacion_aprendizaje" ADD CONSTRAINT "evaluacion_aprendizaje_formula_regla_id_fkey" FOREIGN KEY ("formula_regla_id") REFERENCES "public"."formula_evaluacion_regla"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluacion_aprendizaje" ADD CONSTRAINT "evaluacion_aprendizaje_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "formula_evaluacion_regla" ADD CONSTRAINT "formula_evaluacion_regla_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "formula_evaluacion_subformula" ADD CONSTRAINT "formula_evaluacion_subformula_formula_evaluacion_regla_id_fkey" FOREIGN KEY ("formula_evaluacion_regla_id") REFERENCES "public"."formula_evaluacion_regla"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "formula_evaluacion_variable" ADD CONSTRAINT "formula_evaluacion_variable_formula_evaluacion_regla_id_fkey" FOREIGN KEY ("formula_evaluacion_regla_id") REFERENCES "public"."formula_evaluacion_regla"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "formula_evaluacion_variable_plan" ADD CONSTRAINT "formula_evaluacion_variable_pl_formula_evaluacion_regla_id_fkey" FOREIGN KEY ("formula_evaluacion_regla_id") REFERENCES "public"."formula_evaluacion_regla"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "formula_evaluacion_variable_plan" ADD CONSTRAINT "formula_evaluacion_variable_plan_plan_evaluacion_oferta_id_fkey" FOREIGN KEY ("plan_evaluacion_oferta_id") REFERENCES "public"."plan_evaluacion_oferta"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "plan_evaluacion_oferta" ADD CONSTRAINT "plan_evaluacion_oferta_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_competencia_componente" ADD CONSTRAINT "silabo_competencia_componente_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_competencia_curso" ADD CONSTRAINT "silabo_competencia_curso_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_docente" ADD CONSTRAINT "silabo_docente_docente_id_fkey" FOREIGN KEY ("docente_id") REFERENCES "public"."docente"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_docente" ADD CONSTRAINT "silabo_docente_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_recurso_didactico" ADD CONSTRAINT "silabo_recurso_didactico_recurso_id_fkey" FOREIGN KEY ("recurso_id") REFERENCES "public"."recurso_didactico_catalogo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_recurso_didactico" ADD CONSTRAINT "silabo_recurso_didactico_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_recurso_didactico" ADD CONSTRAINT "silabo_recurso_didactico_silabo_unidad_id_fkey" FOREIGN KEY ("silabo_unidad_id") REFERENCES "public"."silabo_unidad"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_resultado_aprendizaje" ADD CONSTRAINT "silabo_resultado_aprendizaje_curso_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_revision_comentario" ADD CONSTRAINT "silabo_revision_comentario_autor_id_fkey" FOREIGN KEY ("autor_id") REFERENCES "public"."docente"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_revision_comentario" ADD CONSTRAINT "silabo_revision_comentario_silabo_revision_seccion_id_fkey" FOREIGN KEY ("silabo_revision_seccion_id") REFERENCES "public"."silabo_revision_seccion"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_revision_historial" ADD CONSTRAINT "silabo_revision_historial_revisor_id_fkey" FOREIGN KEY ("revisor_id") REFERENCES "public"."docente"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_revision_historial" ADD CONSTRAINT "silabo_revision_historial_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_revision_seccion" ADD CONSTRAINT "silabo_revision_seccion_revisado_por_fkey" FOREIGN KEY ("revisado_por") REFERENCES "public"."docente"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_revision_seccion" ADD CONSTRAINT "silabo_revision_seccion_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_seccion_permiso" ADD CONSTRAINT "silabo_seccion_permiso_docente_id_fkey" FOREIGN KEY ("docente_id") REFERENCES "public"."docente"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_seccion_permiso" ADD CONSTRAINT "silabo_seccion_permiso_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo_sumilla" ADD CONSTRAINT "silabo_sumilla_silabo_id_fkey" FOREIGN KEY ("silabo_id") REFERENCES "public"."silabo"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_audit_event_accion" ON "audit_event" USING btree ("accion" text_ops);--> statement-breakpoint
+CREATE INDEX "idx_audit_event_docente" ON "audit_event" USING btree ("docente_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_audit_event_fecha" ON "audit_event" USING btree ("created_at" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "idx_audit_event_silabo" ON "audit_event" USING btree ("silabo_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_audit_event_tabla_pk" ON "audit_event" USING btree ("tabla" text_ops,"registro_pk" text_ops);--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_docente_correo" ON "docente" USING btree (lower(btrim((correo)::text)));--> statement-breakpoint
+CREATE INDEX "idx_ea_silabo_id" ON "evaluacion_aprendizaje" USING btree ("silabo_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_evaluacion_aprendizaje_silabo" ON "evaluacion_aprendizaje" USING btree ("silabo_id" int4_ops);--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_plan_eval_silabo_componente" ON "plan_evaluacion_oferta" USING btree ("silabo_id" int4_ops,"componente_nombre" text_ops);--> statement-breakpoint
+CREATE INDEX "idx_silabo_recurso" ON "silabo_recurso_didactico" USING btree ("silabo_id" int4_ops,"recurso_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_rev_com_autor" ON "silabo_revision_comentario" USING btree ("autor_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_rev_com_seccion" ON "silabo_revision_comentario" USING btree ("silabo_revision_seccion_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_rev_hist_accion" ON "silabo_revision_historial" USING btree ("accion" text_ops);--> statement-breakpoint
+CREATE INDEX "idx_rev_hist_fecha" ON "silabo_revision_historial" USING btree ("creado_en" timestamp_ops);--> statement-breakpoint
+CREATE INDEX "idx_rev_hist_revisor" ON "silabo_revision_historial" USING btree ("revisor_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_rev_hist_silabo" ON "silabo_revision_historial" USING btree ("silabo_id" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_rev_estado" ON "silabo_revision_seccion" USING btree ("estado" text_ops);--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_silabo_rev_seccion" ON "silabo_revision_seccion" USING btree ("silabo_id" int4_ops,"numero_seccion" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_permiso_seccion" ON "silabo_seccion_permiso" USING btree ("numero_seccion" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_permiso_silabo_docente" ON "silabo_seccion_permiso" USING btree ("silabo_id" int4_ops,"docente_id" int4_ops);--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ADD CONSTRAINT "fk_silabo_unidad" FOREIGN KEY ("silabo_unidad_id") REFERENCES "public"."silabo_unidad"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo" ADD CONSTRAINT "silabo_actualizado_por_docente_id_fkey" FOREIGN KEY ("actualizado_por_docente_id") REFERENCES "public"."docente"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo" ADD CONSTRAINT "silabo_asignado_a_docente_id_fkey" FOREIGN KEY ("asignado_a_docente_id") REFERENCES "public"."docente"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "silabo" ADD CONSTRAINT "silabo_creado_por_docente_id_fkey" FOREIGN KEY ("creado_por_docente_id") REFERENCES "public"."docente"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_silabo_unidad_semana_semana" ON "silabo_unidad_semana" USING btree ("semana" int2_ops);--> statement-breakpoint
+CREATE INDEX "idx_silabo_unidad_semana_unidad_id" ON "silabo_unidad_semana" USING btree ("silabo_unidad_id" int4_ops);--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_silabo_fuente" ON "silabo_fuente" USING btree ("silabo_id" int4_ops,"titulo" text_ops,"anio" int4_ops);--> statement-breakpoint
+CREATE INDEX "idx_silabo_estado" ON "silabo" USING btree ("estado_revision" text_ops);--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_silabo_curso_sem_prog" ON "silabo" USING btree (btrim((curso_codigo)::text),btrim((semestre_academico)::text),btrim((programa_academico)::text));--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_silabo_unidad" ON "silabo_unidad" USING btree ("silabo_id" int4_ops,"numero" int4_ops);--> statement-breakpoint
+ALTER TABLE "funcion_aplicacion" DROP COLUMN "nombre_funcion";--> statement-breakpoint
+ALTER TABLE "funcion_aplicacion" DROP COLUMN "titulo_visible";--> statement-breakpoint
+ALTER TABLE "silabo" DROP COLUMN "horas_totales";--> statement-breakpoint
+ALTER TABLE "silabo" DROP COLUMN "creditos_totales";--> statement-breakpoint
+ALTER TABLE "silabo" DROP COLUMN "docentes_text";--> statement-breakpoint
+ALTER TABLE "silabo" DROP COLUMN "sumilla";--> statement-breakpoint
+ALTER TABLE "silabo" DROP COLUMN "recursos_didacticos";--> statement-breakpoint
+ALTER TABLE "silabo" DROP COLUMN "asignado_a_usuario_autorizado_id";--> statement-breakpoint
+ALTER TABLE "silabo" DROP COLUMN "creado_por_usuario_autorizado_id";--> statement-breakpoint
+ALTER TABLE "silabo" DROP COLUMN "actualizado_por_usuario_autorizado_id";--> statement-breakpoint
+ALTER TABLE "silabo_unidad" DROP COLUMN "semana_inicio";--> statement-breakpoint
+ALTER TABLE "silabo_unidad" DROP COLUMN "semana_fin";--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ADD CONSTRAINT "silabo_unidad_semana_uk" UNIQUE("silabo_unidad_id","semana");--> statement-breakpoint
+ALTER TABLE "funcion_aplicacion" ADD CONSTRAINT "funcion_aplicacion_nombre_funcion_key" UNIQUE("codigo");--> statement-breakpoint
+ALTER TABLE "silabo_unidad" ADD CONSTRAINT "silabo_unidad_silabo_numero_uk" UNIQUE("silabo_id","numero");--> statement-breakpoint
+ALTER TABLE "silabo_unidad_semana" ADD CONSTRAINT "silabo_unidad_semana_semana_check" CHECK ((semana >= 1) AND (semana <= 16));--> statement-breakpoint
+DROP TYPE "public"."aporte_enum";

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,3110 @@
+{
+  "id": "eab720f7-8bea-4376-b9de-aff5ecd5370d",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_event": {
+      "name": "audit_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tabla": {
+          "name": "tabla",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registro_pk": {
+          "name": "registro_pk",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accion": {
+          "name": "accion",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "docente_id": {
+          "name": "docente_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_origen": {
+          "name": "ip_origen",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_values": {
+          "name": "old_values",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_values": {
+          "name": "new_values",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_event_accion": {
+          "name": "idx_audit_event_accion",
+          "columns": [
+            {
+              "expression": "accion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event_docente": {
+          "name": "idx_audit_event_docente",
+          "columns": [
+            {
+              "expression": "docente_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event_fecha": {
+          "name": "idx_audit_event_fecha",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamp_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event_silabo": {
+          "name": "idx_audit_event_silabo",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event_tabla_pk": {
+          "name": "idx_audit_event_tabla_pk",
+          "columns": [
+            {
+              "expression": "tabla",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "registro_pk",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_event_docente_id_fkey": {
+          "name": "audit_event_docente_id_fkey",
+          "tableFrom": "audit_event",
+          "tableTo": "docente",
+          "columnsFrom": ["docente_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_event_silabo_id_fkey": {
+          "name": "audit_event_silabo_id_fkey",
+          "tableFrom": "audit_event",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categoria_funcion": {
+      "name": "categoria_funcion",
+      "schema": "",
+      "columns": {
+        "categoria_usuario_id": {
+          "name": "categoria_usuario_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "funcion_aplicacion_id": {
+          "name": "funcion_aplicacion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categoria_funcion_acceso_categoria_usuario_id_fkey": {
+          "name": "categoria_funcion_acceso_categoria_usuario_id_fkey",
+          "tableFrom": "categoria_funcion",
+          "tableTo": "categoria_usuario",
+          "columnsFrom": ["categoria_usuario_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "categoria_funcion_acceso_funcion_aplicacion_id_fkey": {
+          "name": "categoria_funcion_acceso_funcion_aplicacion_id_fkey",
+          "tableFrom": "categoria_funcion",
+          "tableTo": "funcion_aplicacion",
+          "columnsFrom": ["funcion_aplicacion_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "categoria_funcion_acceso_pk": {
+          "name": "categoria_funcion_acceso_pk",
+          "columns": ["categoria_usuario_id", "funcion_aplicacion_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categoria_usuario": {
+      "name": "categoria_usuario",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nombre_categoria": {
+          "name": "nombre_categoria",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activo": {
+          "name": "activo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "actualizado_en": {
+          "name": "actualizado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categoria_usuario_nombre_categoria_key": {
+          "name": "categoria_usuario_nombre_categoria_key",
+          "nullsNotDistinct": false,
+          "columns": ["nombre_categoria"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.docente": {
+      "name": "docente",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "correo": {
+          "name": "correo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoria_usuario_id": {
+          "name": "categoria_usuario_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activo": {
+          "name": "activo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "azure_ad_object_id": {
+          "name": "azure_ad_object_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ultimo_acceso_en": {
+          "name": "ultimo_acceso_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grado_academico": {
+          "name": "grado_academico",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "actualizado_en": {
+          "name": "actualizado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "nombre_docente": {
+          "name": "nombre_docente",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grado_academico_id": {
+          "name": "grado_academico_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "numero_celular": {
+          "name": "numero_celular",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'999999999'"
+        }
+      },
+      "indexes": {
+        "uq_docente_correo": {
+          "name": "uq_docente_correo",
+          "columns": [
+            {
+              "expression": "lower(btrim((correo)::text))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "docente_categoria_usuario_id_fkey": {
+          "name": "docente_categoria_usuario_id_fkey",
+          "tableFrom": "docente",
+          "tableTo": "categoria_usuario",
+          "columnsFrom": ["categoria_usuario_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "docente_grado_academico_id_fkey": {
+          "name": "docente_grado_academico_id_fkey",
+          "tableFrom": "docente",
+          "tableTo": "grado_academico_catalogo",
+          "columnsFrom": ["grado_academico_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "docente_correo_key": {
+          "name": "docente_correo_key",
+          "nullsNotDistinct": false,
+          "columns": ["correo"]
+        },
+        "uq_docente_numero_celular": {
+          "name": "uq_docente_numero_celular",
+          "nullsNotDistinct": false,
+          "columns": ["numero_celular"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_docente_numero_celular_9dig": {
+          "name": "ck_docente_numero_celular_9dig",
+          "value": "(numero_celular)::text ~ '^[9][0-9]{8}$'::text"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.evaluacion_aprendizaje": {
+      "name": "evaluacion_aprendizaje",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fecha_creacion": {
+          "name": "fecha_creacion",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "formula_regla_id": {
+          "name": "formula_regla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_ea_silabo_id": {
+          "name": "idx_ea_silabo_id",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_evaluacion_aprendizaje_silabo": {
+          "name": "idx_evaluacion_aprendizaje_silabo",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluacion_aprendizaje_formula_regla_id_fkey": {
+          "name": "evaluacion_aprendizaje_formula_regla_id_fkey",
+          "tableFrom": "evaluacion_aprendizaje",
+          "tableTo": "formula_evaluacion_regla",
+          "columnsFrom": ["formula_regla_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evaluacion_aprendizaje_silabo_id_fkey": {
+          "name": "evaluacion_aprendizaje_silabo_id_fkey",
+          "tableFrom": "evaluacion_aprendizaje",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.formula_evaluacion_regla": {
+      "name": "formula_evaluacion_regla",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre_regla": {
+          "name": "nombre_regla",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_final_codigo": {
+          "name": "variable_final_codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expresion_final": {
+          "name": "expresion_final",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "activo": {
+          "name": "activo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "lenguaje": {
+          "name": "lenguaje",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'INFIX'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "formula_evaluacion_regla_silabo_id_fkey": {
+          "name": "formula_evaluacion_regla_silabo_id_fkey",
+          "tableFrom": "formula_evaluacion_regla",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "formula_evaluacion_regla_unq": {
+          "name": "formula_evaluacion_regla_unq",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "nombre_regla", "version"]
+        },
+        "uq_regla_silabo_nombre_version": {
+          "name": "uq_regla_silabo_nombre_version",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "nombre_regla", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.formula_evaluacion_subformula": {
+      "name": "formula_evaluacion_subformula",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "formula_evaluacion_regla_id": {
+          "name": "formula_evaluacion_regla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_codigo": {
+          "name": "variable_codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expresion": {
+          "name": "expresion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "formula_evaluacion_subformula_formula_evaluacion_regla_id_fkey": {
+          "name": "formula_evaluacion_subformula_formula_evaluacion_regla_id_fkey",
+          "tableFrom": "formula_evaluacion_subformula",
+          "tableTo": "formula_evaluacion_regla",
+          "columnsFrom": ["formula_evaluacion_regla_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "formula_evaluacion_subformula_unq": {
+          "name": "formula_evaluacion_subformula_unq",
+          "nullsNotDistinct": false,
+          "columns": ["formula_evaluacion_regla_id", "variable_codigo"]
+        },
+        "uq_subformula_regla_var": {
+          "name": "uq_subformula_regla_var",
+          "nullsNotDistinct": false,
+          "columns": ["formula_evaluacion_regla_id", "variable_codigo"]
+        },
+        "formula_subf_uk": {
+          "name": "formula_subf_uk",
+          "nullsNotDistinct": false,
+          "columns": ["formula_evaluacion_regla_id", "variable_codigo"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.formula_evaluacion_variable": {
+      "name": "formula_evaluacion_variable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "formula_evaluacion_regla_id": {
+          "name": "formula_evaluacion_regla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codigo": {
+          "name": "codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orden": {
+          "name": "orden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "formula_evaluacion_variable_formula_evaluacion_regla_id_fkey": {
+          "name": "formula_evaluacion_variable_formula_evaluacion_regla_id_fkey",
+          "tableFrom": "formula_evaluacion_variable",
+          "tableTo": "formula_evaluacion_regla",
+          "columnsFrom": ["formula_evaluacion_regla_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "formula_evaluacion_variable_unq": {
+          "name": "formula_evaluacion_variable_unq",
+          "nullsNotDistinct": false,
+          "columns": ["formula_evaluacion_regla_id", "codigo"]
+        },
+        "uq_variable_regla_codigo": {
+          "name": "uq_variable_regla_codigo",
+          "nullsNotDistinct": false,
+          "columns": ["formula_evaluacion_regla_id", "codigo"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.formula_evaluacion_variable_plan": {
+      "name": "formula_evaluacion_variable_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "formula_evaluacion_regla_id": {
+          "name": "formula_evaluacion_regla_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variable_codigo": {
+          "name": "variable_codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_evaluacion_oferta_id": {
+          "name": "plan_evaluacion_oferta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "formula_evaluacion_variable_pl_formula_evaluacion_regla_id_fkey": {
+          "name": "formula_evaluacion_variable_pl_formula_evaluacion_regla_id_fkey",
+          "tableFrom": "formula_evaluacion_variable_plan",
+          "tableTo": "formula_evaluacion_regla",
+          "columnsFrom": ["formula_evaluacion_regla_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "formula_evaluacion_variable_plan_plan_evaluacion_oferta_id_fkey": {
+          "name": "formula_evaluacion_variable_plan_plan_evaluacion_oferta_id_fkey",
+          "tableFrom": "formula_evaluacion_variable_plan",
+          "tableTo": "plan_evaluacion_oferta",
+          "columnsFrom": ["plan_evaluacion_oferta_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "formula_evaluacion_variable_plan_unq": {
+          "name": "formula_evaluacion_variable_plan_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "formula_evaluacion_regla_id",
+            "variable_codigo",
+            "plan_evaluacion_oferta_id"
+          ]
+        },
+        "uq_var_plan_regla_var_plan": {
+          "name": "uq_var_plan_regla_var_plan",
+          "nullsNotDistinct": false,
+          "columns": [
+            "formula_evaluacion_regla_id",
+            "variable_codigo",
+            "plan_evaluacion_oferta_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funcion_aplicacion": {
+      "name": "funcion_aplicacion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codigo": {
+          "name": "codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre_publico": {
+          "name": "nombre_publico",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modulo": {
+          "name": "modulo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activo": {
+          "name": "activo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "funcion_aplicacion_nombre_funcion_key": {
+          "name": "funcion_aplicacion_nombre_funcion_key",
+          "nullsNotDistinct": false,
+          "columns": ["codigo"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.grado_academico_catalogo": {
+      "name": "grado_academico_catalogo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codigo": {
+          "name": "codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abreviatura": {
+          "name": "abreviatura",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activo": {
+          "name": "activo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "actualizado_en": {
+          "name": "actualizado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "grado_academico_catalogo_codigo_key": {
+          "name": "grado_academico_catalogo_codigo_key",
+          "nullsNotDistinct": false,
+          "columns": ["codigo"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plan_evaluacion_oferta": {
+      "name": "plan_evaluacion_oferta",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "componente_nombre": {
+          "name": "componente_nombre",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrumento_nombre": {
+          "name": "instrumento_nombre",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semana": {
+          "name": "semana",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fecha": {
+          "name": "fecha",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instrucciones": {
+          "name": "instrucciones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rubrica_url": {
+          "name": "rubrica_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_plan_eval_silabo_componente": {
+          "name": "uq_plan_eval_silabo_componente",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "componente_nombre",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "plan_evaluacion_oferta_silabo_id_fkey": {
+          "name": "plan_evaluacion_oferta_silabo_id_fkey",
+          "tableFrom": "plan_evaluacion_oferta",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plan_evaluacion_oferta_unq": {
+          "name": "plan_evaluacion_oferta_unq",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "componente_nombre", "semana"]
+        },
+        "uq_plan_eval_silabo_comp_semana": {
+          "name": "uq_plan_eval_silabo_comp_semana",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "componente_nombre", "semana"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurso_didactico_catalogo": {
+      "name": "recurso_didactico_catalogo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codigo": {
+          "name": "codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activo": {
+          "name": "activo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "actualizado_en": {
+          "name": "actualizado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recurso_didactico_catalogo_codigo_key": {
+          "name": "recurso_didactico_catalogo_codigo_key",
+          "nullsNotDistinct": false,
+          "columns": ["codigo"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo": {
+      "name": "silabo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "departamento_academico": {
+          "name": "departamento_academico",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "escuela_profesional": {
+          "name": "escuela_profesional",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "programa_academico": {
+          "name": "programa_academico",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "area_curricular": {
+          "name": "area_curricular",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curso_codigo": {
+          "name": "curso_codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "curso_nombre": {
+          "name": "curso_nombre",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "semestre_academico": {
+          "name": "semestre_academico",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tipo_asignatura": {
+          "name": "tipo_asignatura",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tipo_de_estudios": {
+          "name": "tipo_de_estudios",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modalidad_de_asignatura": {
+          "name": "modalidad_de_asignatura",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formato_de_curso": {
+          "name": "formato_de_curso",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciclo": {
+          "name": "ciclo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requisitos": {
+          "name": "requisitos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_teoria": {
+          "name": "horas_teoria",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_practica": {
+          "name": "horas_practica",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_laboratorio": {
+          "name": "horas_laboratorio",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_teoria_lectiva_presencial": {
+          "name": "horas_teoria_lectiva_presencial",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_teoria_lectiva_distancia": {
+          "name": "horas_teoria_lectiva_distancia",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_teoria_no_lectiva_presencial": {
+          "name": "horas_teoria_no_lectiva_presencial",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_teoria_no_lectiva_distancia": {
+          "name": "horas_teoria_no_lectiva_distancia",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_practica_lectiva_presencial": {
+          "name": "horas_practica_lectiva_presencial",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_practica_lectiva_distancia": {
+          "name": "horas_practica_lectiva_distancia",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_practica_no_lectiva_presencial": {
+          "name": "horas_practica_no_lectiva_presencial",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_practica_no_lectiva_distancia": {
+          "name": "horas_practica_no_lectiva_distancia",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditos_teoria": {
+          "name": "creditos_teoria",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditos_practica": {
+          "name": "creditos_practica",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estrategias_metodologicas": {
+          "name": "estrategias_metodologicas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recursos_didacticos_notas": {
+          "name": "recursos_didacticos_notas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "politicas": {
+          "name": "politicas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observaciones": {
+          "name": "observaciones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estado_revision": {
+          "name": "estado_revision",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ASIGNADO'"
+        },
+        "asignado_a_docente_id": {
+          "name": "asignado_a_docente_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creado_por_docente_id": {
+          "name": "creado_por_docente_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actualizado_por_docente_id": {
+          "name": "actualizado_por_docente_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "horasTotales": {
+          "name": "horasTotales",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditosTotales": {
+          "name": "creditosTotales",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_silabo_estado": {
+          "name": "idx_silabo_estado",
+          "columns": [
+            {
+              "expression": "estado_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_silabo_curso_sem_prog": {
+          "name": "uq_silabo_curso_sem_prog",
+          "columns": [
+            {
+              "expression": "btrim((curso_codigo)::text)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "btrim((semestre_academico)::text)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "btrim((programa_academico)::text)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "silabo_actualizado_por_docente_id_fkey": {
+          "name": "silabo_actualizado_por_docente_id_fkey",
+          "tableFrom": "silabo",
+          "tableTo": "docente",
+          "columnsFrom": ["actualizado_por_docente_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "silabo_asignado_a_docente_id_fkey": {
+          "name": "silabo_asignado_a_docente_id_fkey",
+          "tableFrom": "silabo",
+          "tableTo": "docente",
+          "columnsFrom": ["asignado_a_docente_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "silabo_creado_por_docente_id_fkey": {
+          "name": "silabo_creado_por_docente_id_fkey",
+          "tableFrom": "silabo",
+          "tableTo": "docente",
+          "columnsFrom": ["creado_por_docente_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_aporte_resultado_programa": {
+      "name": "silabo_aporte_resultado_programa",
+      "schema": "",
+      "columns": {
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resultado_programa_codigo": {
+          "name": "resultado_programa_codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resultado_programa_descripcion": {
+          "name": "resultado_programa_descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aporte_valor": {
+          "name": "aporte_valor",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "silabo_aporte_resultado_programa_silabo_id_fkey": {
+          "name": "silabo_aporte_resultado_programa_silabo_id_fkey",
+          "tableFrom": "silabo_aporte_resultado_programa",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "silabo_aporte_resultado_programa_pk": {
+          "name": "silabo_aporte_resultado_programa_pk",
+          "columns": ["silabo_id", "resultado_programa_codigo"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_competencia_componente": {
+      "name": "silabo_competencia_componente",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grupo": {
+          "name": "grupo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codigo": {
+          "name": "codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competencia_codigo_relacionada": {
+          "name": "competencia_codigo_relacionada",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orden": {
+          "name": "orden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "silabo_competencia_componente_silabo_id_fkey": {
+          "name": "silabo_competencia_componente_silabo_id_fkey",
+          "tableFrom": "silabo_competencia_componente",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_competencia_curso": {
+      "name": "silabo_competencia_curso",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codigo": {
+          "name": "codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referencia_programa_codigo": {
+          "name": "referencia_programa_codigo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orden": {
+          "name": "orden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "silabo_competencia_curso_silabo_id_fkey": {
+          "name": "silabo_competencia_curso_silabo_id_fkey",
+          "tableFrom": "silabo_competencia_curso",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_docente": {
+      "name": "silabo_docente",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "docente_id": {
+          "name": "docente_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observaciones": {
+          "name": "observaciones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "actualizado_en": {
+          "name": "actualizado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "rol": {
+          "name": "rol",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "silabo_docente_docente_id_fkey": {
+          "name": "silabo_docente_docente_id_fkey",
+          "tableFrom": "silabo_docente",
+          "tableTo": "docente",
+          "columnsFrom": ["docente_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "silabo_docente_silabo_id_fkey": {
+          "name": "silabo_docente_silabo_id_fkey",
+          "tableFrom": "silabo_docente",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "silabo_docente_unq": {
+          "name": "silabo_docente_unq",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "docente_id"]
+        },
+        "uq_silabo_docente_silabo_docente": {
+          "name": "uq_silabo_docente_silabo_docente",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "docente_id"]
+        },
+        "uq_silabo_docente": {
+          "name": "uq_silabo_docente",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "docente_id", "rol"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_fuente": {
+      "name": "silabo_fuente",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autores": {
+          "name": "autores",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anio": {
+          "name": "anio",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "titulo": {
+          "name": "titulo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editorial_revista": {
+          "name": "editorial_revista",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciudad": {
+          "name": "ciudad",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isbn_issn": {
+          "name": "isbn_issn",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doi_url": {
+          "name": "doi_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notas": {
+          "name": "notas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_silabo_fuente": {
+          "name": "uq_silabo_fuente",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "titulo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            },
+            {
+              "expression": "anio",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "silabo_fuente_silabo_id_fkey": {
+          "name": "silabo_fuente_silabo_id_fkey",
+          "tableFrom": "silabo_fuente",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_recurso_didactico": {
+      "name": "silabo_recurso_didactico",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurso_id": {
+          "name": "recurso_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "silabo_unidad_id": {
+          "name": "silabo_unidad_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destino": {
+          "name": "destino",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url_referencia": {
+          "name": "url_referencia",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observaciones": {
+          "name": "observaciones",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "actualizado_en": {
+          "name": "actualizado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "clave_unica": {
+          "name": "clave_unica",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(((((((silabo_id)::text || '-'::text) || (recurso_id)::text) || '-'::text) || COALESCE((silabo_unidad_id)::text, '0'::text)) || '-'::text) || (COALESCE(destino, ''::character varying))::text)",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "idx_silabo_recurso": {
+          "name": "idx_silabo_recurso",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "recurso_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "silabo_recurso_didactico_recurso_id_fkey": {
+          "name": "silabo_recurso_didactico_recurso_id_fkey",
+          "tableFrom": "silabo_recurso_didactico",
+          "tableTo": "recurso_didactico_catalogo",
+          "columnsFrom": ["recurso_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "silabo_recurso_didactico_silabo_id_fkey": {
+          "name": "silabo_recurso_didactico_silabo_id_fkey",
+          "tableFrom": "silabo_recurso_didactico",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "silabo_recurso_didactico_silabo_unidad_id_fkey": {
+          "name": "silabo_recurso_didactico_silabo_unidad_id_fkey",
+          "tableFrom": "silabo_recurso_didactico",
+          "tableTo": "silabo_unidad",
+          "columnsFrom": ["silabo_unidad_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_recurso_por_silabo": {
+          "name": "uq_recurso_por_silabo",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "recurso_id"]
+        },
+        "uq_silabo_recurso": {
+          "name": "uq_silabo_recurso",
+          "nullsNotDistinct": false,
+          "columns": ["clave_unica"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_resultado_aprendizaje": {
+      "name": "silabo_resultado_aprendizaje",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "orden": {
+          "name": "orden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "silabo_resultado_aprendizaje_curso_silabo_id_fkey": {
+          "name": "silabo_resultado_aprendizaje_curso_silabo_id_fkey",
+          "tableFrom": "silabo_resultado_aprendizaje",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "silabo_ra_uk": {
+          "name": "silabo_ra_uk",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "orden"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_revision_comentario": {
+      "name": "silabo_revision_comentario",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_revision_seccion_id": {
+          "name": "silabo_revision_seccion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "autor_id": {
+          "name": "autor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mensaje": {
+          "name": "mensaje",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "leido": {
+          "name": "leido",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_rev_com_autor": {
+          "name": "idx_rev_com_autor",
+          "columns": [
+            {
+              "expression": "autor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rev_com_seccion": {
+          "name": "idx_rev_com_seccion",
+          "columns": [
+            {
+              "expression": "silabo_revision_seccion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "silabo_revision_comentario_autor_id_fkey": {
+          "name": "silabo_revision_comentario_autor_id_fkey",
+          "tableFrom": "silabo_revision_comentario",
+          "tableTo": "docente",
+          "columnsFrom": ["autor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "silabo_revision_comentario_silabo_revision_seccion_id_fkey": {
+          "name": "silabo_revision_comentario_silabo_revision_seccion_id_fkey",
+          "tableFrom": "silabo_revision_comentario",
+          "tableTo": "silabo_revision_seccion",
+          "columnsFrom": ["silabo_revision_seccion_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_revision_historial": {
+      "name": "silabo_revision_historial",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revisor_id": {
+          "name": "revisor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accion": {
+          "name": "accion",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "descripcion": {
+          "name": "descripcion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rev_hist_accion": {
+          "name": "idx_rev_hist_accion",
+          "columns": [
+            {
+              "expression": "accion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rev_hist_fecha": {
+          "name": "idx_rev_hist_fecha",
+          "columns": [
+            {
+              "expression": "creado_en",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "timestamp_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rev_hist_revisor": {
+          "name": "idx_rev_hist_revisor",
+          "columns": [
+            {
+              "expression": "revisor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rev_hist_silabo": {
+          "name": "idx_rev_hist_silabo",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "silabo_revision_historial_revisor_id_fkey": {
+          "name": "silabo_revision_historial_revisor_id_fkey",
+          "tableFrom": "silabo_revision_historial",
+          "tableTo": "docente",
+          "columnsFrom": ["revisor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "silabo_revision_historial_silabo_id_fkey": {
+          "name": "silabo_revision_historial_silabo_id_fkey",
+          "tableFrom": "silabo_revision_historial",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_revision_seccion": {
+      "name": "silabo_revision_seccion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numero_seccion": {
+          "name": "numero_seccion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nombre_seccion": {
+          "name": "nombre_seccion",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estado": {
+          "name": "estado",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDIENTE'"
+        },
+        "revisado_por": {
+          "name": "revisado_por",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revisado_en": {
+          "name": "revisado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "comentarios_count": {
+          "name": "comentarios_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_rev_estado": {
+          "name": "idx_rev_estado",
+          "columns": [
+            {
+              "expression": "estado",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_silabo_rev_seccion": {
+          "name": "uq_silabo_rev_seccion",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "numero_seccion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "silabo_revision_seccion_revisado_por_fkey": {
+          "name": "silabo_revision_seccion_revisado_por_fkey",
+          "tableFrom": "silabo_revision_seccion",
+          "tableTo": "docente",
+          "columnsFrom": ["revisado_por"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "silabo_revision_seccion_silabo_id_fkey": {
+          "name": "silabo_revision_seccion_silabo_id_fkey",
+          "tableFrom": "silabo_revision_seccion",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_rev_seccion_silabo_num": {
+          "name": "uq_rev_seccion_silabo_num",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "numero_seccion"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_seccion_permiso": {
+      "name": "silabo_seccion_permiso",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "docente_id": {
+          "name": "docente_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numero_seccion": {
+          "name": "numero_seccion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "puede_editar": {
+          "name": "puede_editar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "puede_comentar": {
+          "name": "puede_comentar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fecha_limite": {
+          "name": "fecha_limite",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bloqueado_por_estado": {
+          "name": "bloqueado_por_estado",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actualizado_en": {
+          "name": "actualizado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_permiso_seccion": {
+          "name": "idx_permiso_seccion",
+          "columns": [
+            {
+              "expression": "numero_seccion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_permiso_silabo_docente": {
+          "name": "idx_permiso_silabo_docente",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "docente_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "silabo_seccion_permiso_docente_id_fkey": {
+          "name": "silabo_seccion_permiso_docente_id_fkey",
+          "tableFrom": "silabo_seccion_permiso",
+          "tableTo": "docente",
+          "columnsFrom": ["docente_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "silabo_seccion_permiso_silabo_id_fkey": {
+          "name": "silabo_seccion_permiso_silabo_id_fkey",
+          "tableFrom": "silabo_seccion_permiso",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_permiso_silabo_docente_seccion": {
+          "name": "uq_permiso_silabo_docente_seccion",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "docente_id", "numero_seccion"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_sumilla": {
+      "name": "silabo_sumilla",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contenido": {
+          "name": "contenido",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "palabras_clave": {
+          "name": "palabras_clave",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "es_actual": {
+          "name": "es_actual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "silabo_sumilla_silabo_id_fkey": {
+          "name": "silabo_sumilla_silabo_id_fkey",
+          "tableFrom": "silabo_sumilla",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "silabo_sumilla_unq": {
+          "name": "silabo_sumilla_unq",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "version"]
+        },
+        "uq_silabo_sumilla_silabo_version": {
+          "name": "uq_silabo_sumilla_silabo_version",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_unidad": {
+      "name": "silabo_unidad",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "numero": {
+          "name": "numero",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titulo": {
+          "name": "titulo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capacidades_text": {
+          "name": "capacidades_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contenidos_conceptuales": {
+          "name": "contenidos_conceptuales",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contenidos_procedimentales": {
+          "name": "contenidos_procedimentales",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actividades_aprendizaje": {
+          "name": "actividades_aprendizaje",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_lectivas_teoria": {
+          "name": "horas_lectivas_teoria",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_lectivas_practica": {
+          "name": "horas_lectivas_practica",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_no_lectivas_teoria": {
+          "name": "horas_no_lectivas_teoria",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_no_lectivas_practica": {
+          "name": "horas_no_lectivas_practica",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_silabo_unidad": {
+          "name": "uq_silabo_unidad",
+          "columns": [
+            {
+              "expression": "silabo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            },
+            {
+              "expression": "numero",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "silabo_unidad_silabo_id_fkey": {
+          "name": "silabo_unidad_silabo_id_fkey",
+          "tableFrom": "silabo_unidad",
+          "tableTo": "silabo",
+          "columnsFrom": ["silabo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "silabo_unidad_silabo_numero_uk": {
+          "name": "silabo_unidad_silabo_numero_uk",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_id", "numero"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_unidad_backup": {
+      "name": "silabo_unidad_backup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "silabo_id": {
+          "name": "silabo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "numero": {
+          "name": "numero",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "titulo": {
+          "name": "titulo",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacidades_text": {
+          "name": "capacidades_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contenidos_conceptuales": {
+          "name": "contenidos_conceptuales",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contenidos_procedimentales": {
+          "name": "contenidos_procedimentales",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actividades_aprendizaje": {
+          "name": "actividades_aprendizaje",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_lectivas_teoria": {
+          "name": "horas_lectivas_teoria",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_lectivas_practica": {
+          "name": "horas_lectivas_practica",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_no_lectivas_teoria": {
+          "name": "horas_no_lectivas_teoria",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_no_lectivas_practica": {
+          "name": "horas_no_lectivas_practica",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contenidos_conceptuales_semana": {
+          "name": "contenidos_conceptuales_semana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contenidos_procedimentales_semana": {
+          "name": "contenidos_procedimentales_semana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actividades_aprendizaje_semana": {
+          "name": "actividades_aprendizaje_semana",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_lectivas_teoria_semana_arr": {
+          "name": "horas_lectivas_teoria_semana_arr",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_lectivas_practica_semana_arr": {
+          "name": "horas_lectivas_practica_semana_arr",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_no_lectivas_teoria_semana_arr": {
+          "name": "horas_no_lectivas_teoria_semana_arr",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_no_lectivas_practica_semana_arr": {
+          "name": "horas_no_lectivas_practica_semana_arr",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.silabo_unidad_semana": {
+      "name": "silabo_unidad_semana",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "silabo_unidad_id": {
+          "name": "silabo_unidad_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semana": {
+          "name": "semana",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contenidos_conceptuales": {
+          "name": "contenidos_conceptuales",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contenidos_procedimentales": {
+          "name": "contenidos_procedimentales",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actividades_aprendizaje": {
+          "name": "actividades_aprendizaje",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "horas_lectivas_teoria": {
+          "name": "horas_lectivas_teoria",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "horas_lectivas_practica": {
+          "name": "horas_lectivas_practica",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "horas_no_lectivas_teoria": {
+          "name": "horas_no_lectivas_teoria",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "horas_no_lectivas_practica": {
+          "name": "horas_no_lectivas_practica",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "creado_en": {
+          "name": "creado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "actualizado_en": {
+          "name": "actualizado_en",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_silabo_unidad_semana_semana": {
+          "name": "idx_silabo_unidad_semana_semana",
+          "columns": [
+            {
+              "expression": "semana",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int2_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_silabo_unidad_semana_unidad_id": {
+          "name": "idx_silabo_unidad_semana_unidad_id",
+          "columns": [
+            {
+              "expression": "silabo_unidad_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "int4_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fk_silabo_unidad": {
+          "name": "fk_silabo_unidad",
+          "tableFrom": "silabo_unidad_semana",
+          "tableTo": "silabo_unidad",
+          "columnsFrom": ["silabo_unidad_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "silabo_unidad_semana_uk": {
+          "name": "silabo_unidad_semana_uk",
+          "nullsNotDistinct": false,
+          "columns": ["silabo_unidad_id", "semana"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "silabo_unidad_semana_semana_check": {
+          "name": "silabo_unidad_semana_semana_check",
+          "value": "(semana >= 1) AND (semana <= 16)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1758216326629,
       "tag": "0000_far_alex_wilder",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776046775448,
+      "tag": "0001_short_risque",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -463,7 +463,7 @@ export const planEvaluacionOferta = pgTable(
   (table) => [
     uniqueIndex("uq_plan_eval_silabo_componente").using(
       "btree",
-      table.silaboId.asc().nullsLast().op("text_ops"),
+      table.silaboId.asc().nullsLast().op("int4_ops"),
       table.componenteNombre.asc().nullsLast().op("text_ops"),
     ),
     foreignKey({
@@ -561,7 +561,7 @@ export const silaboFuente = pgTable(
       "btree",
       table.silaboId.asc().nullsLast().op("int4_ops"),
       table.titulo.asc().nullsLast().op("text_ops"),
-      table.anio.asc().nullsLast().op("text_ops"),
+      table.anio.asc().nullsLast().op("int4_ops"),
     ),
     foreignKey({
       columns: [table.silaboId],

--- a/package-lock.json
+++ b/package-lock.json
@@ -3477,6 +3477,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -3950,6 +3951,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -6162,6 +6164,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -6197,6 +6200,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/env-paths": {
@@ -6863,6 +6867,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -6997,6 +7002,7 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -7260,6 +7266,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7426,6 +7433,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -8577,6 +8585,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/lru-memoizer": {
@@ -8739,6 +8748,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8922,6 +8932,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -8994,6 +9005,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -9509,6 +9521,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
@@ -9747,6 +9760,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -9765,6 +9779,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -9779,6 +9794,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9788,12 +9804,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9822,6 +9840,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -9834,6 +9853,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10333,6 +10353,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -10351,6 +10372,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -10368,6 +10390,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10377,6 +10400,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -10392,12 +10416,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10412,6 +10438,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,10 +7,9 @@ export function getDb() {
   try {
     const pool = new Pool({
       connectionString: process.env.DATABASE_URL,
-      ssl: {
-        rejectUnauthorized: false,
-      },
+      ssl: false,
     });
+
     return drizzle(pool);
   } catch (error) {
     if (error instanceof Error) {
@@ -20,6 +19,11 @@ export function getDb() {
         "No se pudo conectar a la base de datos",
       );
     }
+
+    throw new AppError(
+      "DatabaseError",
+      "INTERNAL_SERVER_ERROR",
+      "No se pudo conectar a la base de datos",
+    );
   }
-  return null;
 }

--- a/src/functions/uploadSignedSyllabus.ts
+++ b/src/functions/uploadSignedSyllabus.ts
@@ -1,0 +1,113 @@
+import { app } from "@azure/functions";
+import * as fs from "fs";
+import * as path from "path";
+import { sql } from "drizzle-orm";
+import { getDb } from "../db";
+
+const UPLOAD_DIR = path.join(process.cwd(), "uploads", "silabos_firmados");
+
+if (!fs.existsSync(UPLOAD_DIR)) {
+  fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+}
+
+app.http("director_upload_signed_syllabus", {
+  methods: ["POST"],
+  route: "director/syllabi/upload-signed",
+  authLevel: "anonymous",
+  handler: async (req) => {
+    try {
+      const formData = await req.formData();
+
+      const file = formData.get("file") as File | null;
+      const silaboIdRaw = formData.get("silaboId");
+      const cicloRaw = formData.get("ciclo");
+
+      const silaboId = Number(silaboIdRaw);
+      const ciclo = String(cicloRaw ?? "").trim();
+
+      if (!file) {
+        return {
+          status: 400,
+          jsonBody: { message: "Debe seleccionar un archivo PDF" },
+        };
+      }
+
+      if (!Number.isFinite(silaboId) || silaboId <= 0) {
+        return {
+          status: 400,
+          jsonBody: { message: "Debe seleccionar una asignatura válida" },
+        };
+      }
+
+      if (!ciclo) {
+        return {
+          status: 400,
+          jsonBody: { message: "Debe seleccionar un ciclo" },
+        };
+      }
+
+      if (file.type !== "application/pdf") {
+        return {
+          status: 400,
+          jsonBody: { message: "Solo se permiten archivos PDF" },
+        };
+      }
+
+      const db = getDb();
+
+      const syllabusResult = await db.execute(sql`
+        SELECT id, curso_codigo, curso_nombre
+        FROM silabo
+        WHERE id = ${silaboId}
+        LIMIT 1
+      `);
+
+      const syllabus = syllabusResult.rows?.[0];
+
+      if (!syllabus) {
+        return {
+          status: 404,
+          jsonBody: { message: "Sílabo no encontrado" },
+        };
+      }
+
+      const safeFileName = `${silaboId}_${Date.now()}_${file.name.replace(/\s+/g, "_")}`;
+      const filePath = path.join(UPLOAD_DIR, safeFileName);
+
+      const arrayBuffer = await file.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+
+      fs.writeFileSync(filePath, buffer);
+
+      await db.execute(sql`
+        INSERT INTO silabo_archivo_firmado (
+          silabo_id,
+          ciclo,
+          nombre_archivo,
+          ruta_archivo
+        )
+        VALUES (
+          ${silaboId},
+          ${ciclo},
+          ${file.name},
+          ${filePath}
+        )
+      `);
+
+      return {
+        status: 200,
+        jsonBody: {
+          message: "Archivo subido correctamente",
+          fileName: file.name,
+          filePath,
+        },
+      };
+    } catch (error) {
+      console.error("Error subiendo sílabo firmado:", error);
+      return {
+        status: 500,
+        jsonBody: { message: "Error al subir archivo" },
+      };
+    }
+  },
+});


### PR DESCRIPTION
📝 Descripción
Se implementa la funcionalidad para recibir sílabos aprobados e importar sílabos con firma digital. Se corrigió la configuración SSL de la base de datos y los índices text_ops incompatibles con columnas integer en el schema de Drizzle.
✅ ¿Qué se incluye en este PR?

 Nueva funcionalidad Backend
 Refactor / Ajuste
🧪 Cómo probarlo
bash npm install
# Iniciar Azurite en una terminal aparte
azurite --silent --location c:\azurite --debug c:\azurite\debug.log
# Iniciar el backend
npm run start
# Verificar health
GET http://localhost:7071/api/health